### PR TITLE
Fix a bug that causes touch responses to not work correctly on Alexa …

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -31,7 +31,7 @@ const ListItemPressedHandler = {
     return request.type === 'Alexa.Presentation.APL.UserEvent' && request.arguments.length > 0;
   },
   handle(handlerInput) {
-    const selectedItem = handlerInput.requestEnvelope.request.arguments[0];
+    const selectedItem = Number(handlerInput.requestEnvelope.request.arguments[0]);
     return handlerInput.responseBuilder
           .speak("Here is the video, enjoy!")
           .addDirective({


### PR DESCRIPTION
…devices

The value fireTVVlogsData.properties.selectedItem is set to a string instead of a number when the ListItemPressedHandler.handle is invoked via a touch interaction (UserEvent). This causes the resulting APL to render incorrectly on devices. Works okay on simulator though. This issue has been reported to the device team.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
